### PR TITLE
Build : Allow building from separate dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0)
 project(AtomsGaffer)
 
+option( USE_GAFFER_DEPENDENCIES "Turn this off you're building against your own dependencies (eg boost, python, tbb, exr, cortex) rather than the versions included with Gaffer" ON )
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
@@ -16,12 +18,30 @@ if(ATOMS_ROOT)
     set(ATOMS_ICONS_PATH ${ATOMS_ROOT}/icons)
 endif()
 
+if(USE_GAFFER_DEPENDENCIES)
+    set(BOOST_INCLUDE_PATH ${GAFFER_ROOT}/include)
+    set(PYTHON_ROOT ${GAFFER_ROOT})
+    set(TBB_ROOT ${GAFFER_ROOT})
+    set(OPENEXR_ROOT ${GAFFER_ROOT})
+    set(CORTEX_ROOT ${GAFFER_ROOT})
+endif()
+
+set(DEPENDENCY_INCLUDE_PATHS
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_ROOT}/include
+    ${OPENEXR_ROOT}/include
+    ${OPENEXR_ROOT}/include/OpenEXR
+    ${CORTEX_ROOT}/include
+    ${GAFFER_ROOT}/include
+    ${ATOMS_INCLUDE_PATH}
+)
+
 # build the library
 file( GLOB AtomsGafferSrc src/AtomsGaffer/*.cpp )
 link_directories( AtomsGaffer ${GAFFER_ROOT}/lib ${ATOMS_LIB_PATH} )
 add_library( AtomsGaffer SHARED ${AtomsGafferSrc} )
 target_compile_definitions( AtomsGaffer PRIVATE BOOST_SIGNALS_NO_DEPRECATION_WARNING=1 LINUX=1 )
-target_include_directories( AtomsGaffer PRIVATE include ${GAFFER_ROOT}/include ${ATOMS_INCLUDE_PATH} ${GAFFER_ROOT}/include/OpenEXR )
+target_include_directories( AtomsGaffer PRIVATE include ${DEPENDENCY_INCLUDE_PATHS} )
 target_link_libraries( AtomsGaffer Gaffer GafferScene AtomsProcedural )
 install( TARGETS AtomsGaffer DESTINATION lib )
 
@@ -31,7 +51,7 @@ add_library( AtomsGafferModule SHARED ${AtomsGafferModuleSrc} )
 set_target_properties( AtomsGafferModule PROPERTIES PREFIX "" OUTPUT_NAME "_AtomsGaffer" )
 target_compile_definitions( AtomsGafferModule PRIVATE BOOST_SIGNALS_NO_DEPRECATION_WARNING=1 LINUX=1 )
 target_link_libraries( AtomsGafferModule AtomsGaffer )
-target_include_directories( AtomsGafferModule PRIVATE include ${GAFFER_ROOT}/include ${GAFFER_ROOT}/include/OpenEXR  ${GAFFER_ROOT}/include/python2.7 ${ATOMS_INCLUDE_PATH} )
+target_include_directories( AtomsGafferModule PRIVATE include ${DEPENDENCY_INCLUDE_PATHS} ${PYTHON_ROOT}/include/python2.7 )
 target_link_libraries( AtomsGafferModule GafferBindings )
 install( TARGETS AtomsGafferModule DESTINATION python/AtomsGaffer )
 


### PR DESCRIPTION
Rather than using the public gaffer dependencies, we might want to build against separate boost, python, tbb, exr, and cortex installations.

The default is still to use the public Gaffer dependencies.