### PR TITLE
Protect engine plugs with the Gaffer 0.54 computeCachePolicy

### DIFF
--- a/include/AtomsGaffer/AtomsCrowdReader.h
+++ b/include/AtomsGaffer/AtomsCrowdReader.h
@@ -80,6 +80,8 @@ class AtomsCrowdReader : public GafferScene::ObjectSource
 
 	protected:
 
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
 		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 

--- a/include/AtomsGaffer/AtomsVariationReader.h
+++ b/include/AtomsGaffer/AtomsVariationReader.h
@@ -85,6 +85,8 @@ class AtomsVariationReader : public GafferScene::SceneNode
 
 	protected:
 
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
 		void hashBound( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		void hashTransform( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		void hashAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;

--- a/src/AtomsGaffer/AtomsCrowdReader.cpp
+++ b/src/AtomsGaffer/AtomsCrowdReader.cpp
@@ -447,6 +447,18 @@ void AtomsCrowdReader::affects( const Plug *input, AffectedPlugsContainer &outpu
 	}
 }
 
+Gaffer::ValuePlug::CachePolicy AtomsCrowdReader::computeCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if( output == enginePlug() )
+	{
+		// Request blocking compute for the engine, to avoid concurrent threads
+		// loading the same engine redundantly.
+		return ValuePlug::CachePolicy::Standard;
+	}
+
+	return ObjectSource::computeCachePolicy( output );
+}
+
 void AtomsCrowdReader::hashSource( const Gaffer::Context *context, MurmurHash &h ) const
 {
 	atomsSimFilePlug()->hash( h );

--- a/src/AtomsGaffer/AtomsVariationReader.cpp
+++ b/src/AtomsGaffer/AtomsVariationReader.cpp
@@ -1007,6 +1007,18 @@ void AtomsVariationReader::affects( const Plug *input, AffectedPlugsContainer &o
     SceneNode::affects( input, outputs );
 }
 
+Gaffer::ValuePlug::CachePolicy AtomsVariationReader::computeCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if( output == enginePlug() )
+	{
+		// Request blocking compute for the engine, to avoid concurrent threads
+        // loading the same engine redundantly.
+		return ValuePlug::CachePolicy::Standard;
+	}
+
+	return SceneNode::computeCachePolicy( output );
+}
+
 void AtomsVariationReader::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneNode::hashBound( path, context, parent, h );


### PR DESCRIPTION
The EnginePlugs can be expensive to compute, so we want to make sure we don't compute them from multiple threads at once.

This change reduced max resident size on a production example from 15.97Gb to 6.78Gb

Fixes #36