### PR TITLE
AtomsVariationReader: hashing improvements

### DIFF
--- a/src/AtomsGaffer/AtomsCrowdGenerator.cpp
+++ b/src/AtomsGaffer/AtomsCrowdGenerator.cpp
@@ -718,7 +718,7 @@ ConstCompoundObjectPtr AtomsCrowdGenerator::computeBranchAttributes( const Scene
         }
 
         // Need to find with point has the data of the current agent
-        std::vector<int> agentIdVec = agentIdData->readable();
+        const std::vector<int> &agentIdVec = agentIdData->readable();
         for ( size_t i = 0; i < agentIdVec.size(); ++i )
         {
             if ( agentIdVec[i] == currentAgentIndex )
@@ -902,7 +902,7 @@ ConstObjectPtr AtomsCrowdGenerator::computeBranchObject( const ScenePath &parent
 
     // Get the point id that contain the agent data
     // We need this only to get blend shapes weights information
-    std::vector<int> agentIdVec = agentIdData->readable();
+    const std::vector<int> &agentIdVec = agentIdData->readable();
 
     for ( size_t i = 0; i < agentIdVec.size(); ++i )
     {
@@ -1163,9 +1163,6 @@ ConstPathMatcherDataPtr AtomsCrowdGenerator::computeBranchSet( const ScenePath &
 	for( const auto &agentName : agentNames->readable() )
 	{
 		agentPath.back() = agentName;
-
-        std::vector<std::string> paths;
-        inputSet->readable().paths( paths );
 
 		PathMatcher instanceSet = inputSet->readable().subTree( agentPath );
 		auto variationNamesData = instanceChildNames->member<CompoundData>( agentName );

--- a/src/AtomsGaffer/AtomsCrowdReader.cpp
+++ b/src/AtomsGaffer/AtomsCrowdReader.cpp
@@ -461,7 +461,7 @@ Gaffer::ValuePlug::CachePolicy AtomsCrowdReader::computeCachePolicy( const Gaffe
 
 void AtomsCrowdReader::hashSource( const Gaffer::Context *context, MurmurHash &h ) const
 {
-	atomsSimFilePlug()->hash( h );
+	h.append( atomsSimFilePlug()->getValue() );
 	refreshCountPlug()->hash( h );
 	timeOffsetPlug()->hash( h );
     agentIdsPlug()->hash( h );
@@ -632,7 +632,8 @@ ConstObjectPtr AtomsCrowdReader::computeSource( const Gaffer::Context *context )
 
 void AtomsCrowdReader::hashAttributes( const ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-    atomsSimFilePlug()->hash( h );
+    GafferScene::ObjectSource::hashAttributes( path, context, parent, h );
+    h.append( atomsSimFilePlug()->getValue() );
     refreshCountPlug()->hash( h );
     timeOffsetPlug()->hash( h );
     agentIdsPlug()->hash( h );
@@ -775,9 +776,10 @@ IECore::ConstCompoundObjectPtr AtomsCrowdReader::computeAttributes( const SceneN
 
 void AtomsCrowdReader::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
+    ObjectSource::hash( output, context, h );
     if( output == enginePlug() )
     {
-        atomsSimFilePlug()->hash( h );
+        h.append( atomsSimFilePlug()->getValue() );
         refreshCountPlug()->hash( h );
         timeOffsetPlug()->hash( h );
         agentIdsPlug()->hash( h );
@@ -789,7 +791,6 @@ void AtomsCrowdReader::hash( const Gaffer::ValuePlug *output, const Gaffer::Cont
         enginePlug()->hash( h );
         h.append( context->getFrame() );
     }
-    ObjectSource::hash( output, context, h );
 }
 
 void AtomsCrowdReader::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const

--- a/src/AtomsGaffer/AtomsVariationReader.cpp
+++ b/src/AtomsGaffer/AtomsVariationReader.cpp
@@ -1023,7 +1023,7 @@ void AtomsVariationReader::hashBound( const ScenePath &path, const Gaffer::Conte
 {
 	SceneNode::hashBound( path, context, parent, h );
 
-    atomsVariationFilePlug()->hash( h );
+	h.append( atomsVariationFilePlug()->getValue() );
 	refreshCountPlug()->hash( h );
 
 	h.append( &path.front(), path.size() );
@@ -1085,7 +1085,7 @@ void AtomsVariationReader::hashTransform( const ScenePath &path, const Gaffer::C
         const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneNode::hashTransform( path, context, parent, h );
-    atomsVariationFilePlug()->hash( h );
+	h.append( atomsVariationFilePlug()->getValue() );
 	refreshCountPlug()->hash( h );
 
 	h.append( &path.front(), path.size() );
@@ -1147,7 +1147,7 @@ Imath::M44f AtomsVariationReader::computeTransform( const ScenePath &path, const
 void AtomsVariationReader::hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneNode::hashAttributes( path, context, parent, h );
-    atomsVariationFilePlug()->hash( h );
+	h.append( atomsVariationFilePlug()->getValue() );
 	refreshCountPlug()->hash( h );
 
 	h.append( &path.front(), path.size() );
@@ -1369,7 +1369,7 @@ void AtomsVariationReader::hashObject( const ScenePath &path, const Gaffer::Cont
         const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneNode::hashObject( path, context, parent, h );
-    atomsVariationFilePlug()->hash( h );
+	h.append( atomsVariationFilePlug()->getValue() );
 	refreshCountPlug()->hash( h );
     generatePrefPlug()->hash( h );
     generateNrefPlug()->hash( h );
@@ -1461,7 +1461,7 @@ void AtomsVariationReader::hashChildNames( const ScenePath &path, const Gaffer::
         const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneNode::hashChildNames( path, context, parent, h );
-    atomsVariationFilePlug()->hash( h );
+	h.append( atomsVariationFilePlug()->getValue() );
 	refreshCountPlug()->hash( h );
 	h.append( &path.front(), path.size() );
 }
@@ -1526,7 +1526,7 @@ void AtomsVariationReader::hashSetNames( const Gaffer::Context *context, const S
 {
 	SceneNode::hashSetNames( context, parent, h );
 
-    atomsVariationFilePlug()->hash( h );
+	h.append( atomsVariationFilePlug()->getValue() );
 	refreshCountPlug()->hash( h );
 }
 
@@ -1593,7 +1593,7 @@ void AtomsVariationReader::hashSet( const IECore::InternedString &setName, const
 {
 	SceneNode::hashSet( setName, context, parent, h );
 
-    atomsVariationFilePlug()->hash( h );
+	h.append( atomsVariationFilePlug()->getValue() );
 	refreshCountPlug()->hash( h );
 	h.append( setName );
 }
@@ -1706,7 +1706,7 @@ void AtomsVariationReader::hash( const Gaffer::ValuePlug *output, const Gaffer::
 {
 	if( output == enginePlug() )
 	{
-        atomsVariationFilePlug()->hash( h );
+		h.append( atomsVariationFilePlug()->getValue() );
 		refreshCountPlug()->hash( h );
 	}
 


### PR DESCRIPTION
This update addresses performance issues discovered during production rendering of Atoms crowds at Cinesite. Some of the updates were recommended by John Haddon after reviewing the code (I will post John's original messages as comments). The other updates were based on an observation that any filepaths generated by an expression can produce different hashes for the same paths. This would cause gaffer to repeat heavy (serial) computations instead of using cached values. This specific issue was resolved by hashing the actual values of the filepaths instead of hashing the expressions that generate these paths.

Here are some stats from the testing:
Crowd:
- 35.000 agents
- 45.000 vertices, 30 meshes per agent

farm expansion time:
- before: 30m - 2h
- after: 1-4m
ui: bounding-box time and memory use:
- before: 1 min, 18 GB
- after: 15 sec, 10 GB