### PR TITLE
Fix dirtying issues in affects() methods

### DIFF
--- a/include/AtomsGaffer/AtomsCrowdGenerator.h
+++ b/include/AtomsGaffer/AtomsCrowdGenerator.h
@@ -81,24 +81,31 @@ class AtomsCrowdGenerator : public GafferScene::BranchCreator
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
+		bool affectsBranchBound( const Gaffer::Plug *input ) const override;
 		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
+		bool affectsBranchTransform( const Gaffer::Plug *input ) const override;
 		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
+		bool affectsBranchAttributes( const Gaffer::Plug *input ) const override;
 		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
+		bool affectsBranchObject( const Gaffer::Plug *input ) const override;
 		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
+		bool affectsBranchChildNames( const Gaffer::Plug *input ) const override;
 		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
+		bool affectsBranchSetNames( const Gaffer::Plug *input ) const override;
 		void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const override;
 
+		bool affectsBranchSet( const Gaffer::Plug *input ) const override;
 		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
 

--- a/src/AtomsGaffer/AtomsCrowdClothReader.cpp
+++ b/src/AtomsGaffer/AtomsCrowdClothReader.cpp
@@ -97,6 +97,8 @@ const IntPlug* AtomsCrowdClothReader::refreshCountPlug() const
 
 void AtomsCrowdClothReader::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 {
+    SceneProcessor::affects(input, outputs);
+
     if( input == inPlug()->objectPlug() || input == inPlug()->attributesPlug() ||
         input == atomsClothFilePlug() || input == refreshCountPlug() )
     {

--- a/src/AtomsGaffer/AtomsCrowdGenerator.cpp
+++ b/src/AtomsGaffer/AtomsCrowdGenerator.cpp
@@ -139,62 +139,12 @@ void AtomsCrowdGenerator::affects( const Plug *input, AffectedPlugsContainer &ou
 	if(
 		input == inPlug()->objectPlug() ||
         input == inPlug()->attributesPlug() ||
-		input == variationsPlug()->childNamesPlug()
+		input == variationsPlug()->childNamesPlug() ||
+        input == useInstancesPlug()
 	)
 	{
 		outputs.push_back( agentChildNamesPlug() );
 	}
-
-	if(
-		input == namePlug() ||
-		input == agentChildNamesPlug() ||
-		input == variationsPlug()->childNamesPlug()
-	)
-	{
-		outputs.push_back( outPlug()->childNamesPlug() );
-	}
-
-	if(
-		input == inPlug()->objectPlug() ||
-		input == inPlug()->attributesPlug() ||
-		input == namePlug() ||
-		input == variationsPlug()->boundPlug() ||
-		input == variationsPlug()->transformPlug() ||
-		input == agentChildNamesPlug() ||
-		input == boundingBoxPaddingPlug() ||
-		input == clothCachePlug()->objectPlug()
-	)
-	{
-		outputs.push_back( outPlug()->boundPlug() );
-	}
-
-	if(
-		input == inPlug()->objectPlug() ||
-		input == inPlug()->attributesPlug() ||
-		input == variationsPlug()->transformPlug()
-	)
-	{
-		outputs.push_back( outPlug()->transformPlug() );
-	}
-
-	if(
-		input == variationsPlug()->attributesPlug() ||
-		input == inPlug()->objectPlug() ||
-		input == inPlug()->attributesPlug()
-	)
-	{
-		outputs.push_back( outPlug()->attributesPlug() );
-	}
-
-    if( input == variationsPlug()->objectPlug() ||
-        input == variationsPlug()->attributesPlug() ||
-        input == inPlug()->objectPlug() ||
-        input == inPlug()->attributesPlug() ||
-        input == clothCachePlug()->objectPlug()
-        )
-    {
-        outputs.push_back( outPlug()->objectPlug() );
-    }
 }
 
 void AtomsCrowdGenerator::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, MurmurHash &h ) const
@@ -371,6 +321,19 @@ void AtomsCrowdGenerator::compute( Gaffer::ValuePlug *output, const Gaffer::Cont
 	BranchCreator::compute( output, context );
 }
 
+bool AtomsCrowdGenerator::affectsBranchBound( const Gaffer::Plug *input ) const
+{
+	return ( input == inPlug()->objectPlug() ||
+			 input == inPlug()->attributesPlug() ||
+			 input == inPlug()->boundPlug() ||
+			 input == namePlug() ||
+			 input == variationsPlug()->boundPlug() ||
+			 input == variationsPlug()->transformPlug() ||
+			 input == agentChildNamesPlug() ||
+			 input == boundingBoxPaddingPlug() ||
+			 input == clothCachePlug()->objectPlug() );
+}
+
 void AtomsCrowdGenerator::hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, MurmurHash &h ) const
 {
 	if( branchPath.size() < 4 )
@@ -518,6 +481,13 @@ Imath::Box3f AtomsCrowdGenerator::computeBranchBound( const ScenePath &parentPat
     }
 }
 
+bool AtomsCrowdGenerator::affectsBranchTransform( const Gaffer::Plug *input ) const
+{
+	return ( input == inPlug()->objectPlug() ||
+			 input == inPlug()->attributesPlug() ||
+			 input == variationsPlug()->transformPlug() );
+}
+
 void AtomsCrowdGenerator::hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, MurmurHash &h ) const
 {
 
@@ -563,6 +533,13 @@ Imath::M44f AtomsCrowdGenerator::computeBranchTransform( const ScenePath &parent
 		AgentScope scope( context, branchPath );
 		return variationsPlug()->transformPlug()->getValue();
 	}
+}
+
+bool AtomsCrowdGenerator::affectsBranchAttributes( const Gaffer::Plug *input ) const
+{
+	return ( input == variationsPlug()->attributesPlug() ||
+			 input == inPlug()->objectPlug() ||
+			 input == inPlug()->attributesPlug() );
 }
 
 void AtomsCrowdGenerator::hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, MurmurHash &h ) const
@@ -842,6 +819,16 @@ ConstCompoundObjectPtr AtomsCrowdGenerator::computeBranchAttributes( const Scene
 	}
 }
 
+bool AtomsCrowdGenerator::affectsBranchObject( const Gaffer::Plug *input ) const
+{
+	return ( input == variationsPlug()->objectPlug() ||
+			 input == variationsPlug()->attributesPlug() ||
+			 input == inPlug()->objectPlug() ||
+			 input == inPlug()->attributesPlug() ||
+			 input == clothCachePlug()->objectPlug() ||
+			 input == useInstancesPlug() );
+}
+
 void AtomsCrowdGenerator::hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, MurmurHash &h ) const
 {
 	if( branchPath.size() <= 4 )
@@ -1030,6 +1017,13 @@ ConstObjectPtr AtomsCrowdGenerator::computeBranchObject( const ScenePath &parent
     return result;
 }
 
+bool AtomsCrowdGenerator::affectsBranchChildNames( const Gaffer::Plug *input ) const
+{
+	return ( input == namePlug() ||
+			 input == agentChildNamesPlug() ||
+			 input == variationsPlug()->childNamesPlug() );
+}
+
 void AtomsCrowdGenerator::hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, MurmurHash &h ) const
 {
 	if( branchPath.empty() )
@@ -1128,6 +1122,11 @@ ConstInternedStringVectorDataPtr AtomsCrowdGenerator::computeBranchChildNames( c
 	}
 }
 
+bool AtomsCrowdGenerator::affectsBranchSetNames( const Gaffer::Plug *input ) const
+{
+	return ( input == variationsPlug()->setNamesPlug() );
+}
+
 void AtomsCrowdGenerator::hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, MurmurHash &h ) const
 {
 	h = variationsPlug()->setNamesPlug()->hash();
@@ -1136,6 +1135,14 @@ void AtomsCrowdGenerator::hashBranchSetNames( const ScenePath &parentPath, const
 ConstInternedStringVectorDataPtr AtomsCrowdGenerator::computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const
 {
 	return variationsPlug()->setNamesPlug()->getValue();
+}
+
+bool AtomsCrowdGenerator::affectsBranchSet( const Gaffer::Plug *input ) const
+{
+	return ( input == variationsPlug()->childNamesPlug() ||
+			 input == agentChildNamesPlug() ||
+			 input == variationsPlug()->setPlug() ||
+			 input == namePlug() );
 }
 
 void AtomsCrowdGenerator::hashBranchSet( const ScenePath &parentPath, const InternedString &setName, const Gaffer::Context *context, MurmurHash &h ) const


### PR DESCRIPTION
The `affects()` methods of the `AtomsCrowdGenerator` and `AtomsCrowdClothReader` nodes have been fixed by adding missing input plugs and a call to the base class in `AtomsCrowdClothReader`. In `AtomsCrowdGenerator`, most of the logic has been moved to the matching `BranchCreator::affectsBranch...()` method, since they are internally used by `BranchCreator` to dirty its internal plugs.

In Gaffer 0.58+, changes in the dirtying mechanism makes it important to have the behavior of `affects()` methods match the affects relationships of the hash/compute methods. Relationships not defined in `affects()` result in a failure to update the right outputs when an input  plug is changed.