### PR TITLE
Minor performances fix and a small bug fix

### DIFF
--- a/src/AtomsGaffer/AtomsCrowdGenerator.cpp
+++ b/src/AtomsGaffer/AtomsCrowdGenerator.cpp
@@ -667,12 +667,19 @@ ConstCompoundObjectPtr AtomsCrowdGenerator::computeBranchAttributes( const Scene
 
         // Need to find with point has the data of the current agent
         const std::vector<int> &agentIdVec = agentIdData->readable();
-        for ( size_t i = 0; i < agentIdVec.size(); ++i )
+        if (agentIdVec[currentAgentIndex] == currentAgentIndex)
         {
-            if ( agentIdVec[i] == currentAgentIndex )
+            agentIdPointIndex = currentAgentIndex;
+        }
+        else
+        {
+            for (size_t i = 0; i < agentIdVec.size(); ++i)
             {
-                agentIdPointIndex = i;
-                break;
+                if (agentIdVec[i] == currentAgentIndex)
+                {
+                    agentIdPointIndex = i;
+                    break;
+                }
             }
         }
 
@@ -864,12 +871,21 @@ ConstObjectPtr AtomsCrowdGenerator::computeBranchObject( const ScenePath &parent
     // We need this only to get blend shapes weights information
     const std::vector<int> &agentIdVec = agentIdData->readable();
 
-    for ( size_t i = 0; i < agentIdVec.size(); ++i )
+    // Fetch agent id. In most cases, the array index matches the agent id.
+    if (agentIdVec[currentAgentIndex] == currentAgentIndex)
     {
-        if ( agentIdVec[i] == currentAgentIndex )
+        agentIdPointIndex = currentAgentIndex;
+    }
+    else
+    {
+        std::cout << "Index did not match... Doing a linear search!" << std::endl;
+        for ( size_t i = 0; i < agentIdVec.size(); ++i )
         {
-            agentIdPointIndex = i;
-            break;
+            if ( agentIdVec[i] == currentAgentIndex )
+            {
+                agentIdPointIndex = i;
+                break;
+            }
         }
     }
 
@@ -1459,7 +1475,6 @@ void AtomsCrowdGenerator::applySkinDeformer(
 
         currentNormal *= transfromNormalMatrix;
         currentNormal.w = 0.0;
-        currentNormal.normalize();
 
         for ( size_t jId = 0; jId < jointIndexCountVec[pointId]; ++jId ) {
             int jointId = jointIndicesVec[offset];
@@ -1467,8 +1482,6 @@ void AtomsCrowdGenerator::applySkinDeformer(
         }
 
         newN *= transfromNormalMatrix;
-        newN.w = 0.0;
-        newN.normalize();
 
         inNormal.x = newN.x;
         inNormal.y = newN.y;

--- a/src/AtomsGaffer/AtomsCrowdGenerator.cpp
+++ b/src/AtomsGaffer/AtomsCrowdGenerator.cpp
@@ -1481,7 +1481,7 @@ void AtomsCrowdGenerator::applySkinDeformer(
             newN += currentNormal * jointWeightsVec[offset] * worldMatrices[jointId];
         }
 
-        newN *= transfromNormalMatrix;
+        newN *= transfromNormalInverseMatrix;
 
         inNormal.x = newN.x;
         inNormal.y = newN.y;


### PR DESCRIPTION
First of all, this branch contains some minor performance fixes:
1) For this one, the credits go to Alexander who pointed it out. In most cases, an agent id's will match its index in the agents list. When fetching an agent id from its index, we can save time by first looking if the index matches the id. This avoids having to loop over all entries in the vector, which does not scale well as the number of agents increases. 
2) Most of the time is generally spent computing the skin deformation. During that operation, roughly 5% of the time was spent on non required normalization of 4D vectors. These extra computations have been removed. In my test with ~750 agents, this was roughly ~2s, which is not much, but as the number of agents and/or their mesh complexity increases, this could save some more time.
3) Loading the scene hierarchy of the AtomsVariationReader or AtomsCrowdGenerator nodes in Gaffer, it can take a few seconds to process. Most of the time is spent on loading the atoms meshes in AtomsVariationReader. To speed things up, all meshes from one agent are now loaded in parallel, which significantly improves responsiveness. Note that the gain is limited when processing more that the atoms node, since other nodes might be processed on other cores, e.g., during a render. Also note that this is a quick fix, but a better solution, which would take more time to implement, would be to change the way we load atoms data. Instead of loading everything at once, we could load only the required information to generate the child names, bbox, etc., and then load the meshes only when requested.

Also, this branch contains a small bug fix I found while looking at the skin deformation code in AtomsCrowdGenerator. Instead of using the normals matrix's inverse to transform the normals back to local space, the normals matrix (local to world) is used instead. I believe this has not been detected before because the agent's transformation matrices only contained translation information, with the inner 3x3 matrix being the identity. 