### PR TITLE
AtomsCrowdGenerator: Fix clashing agent variation names

### DIFF
--- a/src/AtomsGaffer/AtomsCrowdGenerator.cpp
+++ b/src/AtomsGaffer/AtomsCrowdGenerator.cpp
@@ -1008,20 +1008,27 @@ void AtomsCrowdGenerator::hashBranchChildNames( const ScenePath &parentPath, con
 	else if( branchPath.size() == 1 )
 	{
 		// "/agents"
+		BranchCreator::hashBranchChildNames( parentPath, branchPath, context, h );
+		agentChildNamesHash( parentPath, context, h );
+	}
+	else if( branchPath.size() == 2 )
+	{
+		// "/agents/<agentType>"
         BranchCreator::hashBranchChildNames( parentPath, branchPath, context, h );
         agentChildNamesHash( parentPath, context, h );
         h.append( branchPath.back() );
 	}
-	else if( branchPath.size() <= 3 )
+	else if( branchPath.size() == 3 )
 	{
-		// "/agents/<agentType>" or "/agents/<agentType>/<variation>"
+		// "/agents/<agentType>/<variation>"
 		BranchCreator::hashBranchChildNames( parentPath, branchPath, context, h );
 		agentChildNamesHash( parentPath, context, h );
+		h.append( branchPath[1] );
 		h.append( branchPath.back() );
 	}
 	else
 	{
-		// "/agents/<agentName>/<id>/..."
+		// "/agents/<agentType>/<variation>/<id>/..."
 		AgentScope scope( context, branchPath );
 		h = variationsPlug()->childNamesPlug()->hash();
 	}


### PR DESCRIPTION
This PR addresses the bug described in Issue #16.

If there are multiple agents with the same variation name, this was not taken into account when hashing the child branch names and led to accessing the wrong context.

I have aligned the layout of the `hashBranchChildNames` with the `computeBranchChildNames` by adding distinct clauses based on the path size, so that the variations are handled correctly by also taking the agentType into account