### PR TITLE
CMakeLists.txt: Support for Gaffer 1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if(USE_GAFFER_DEPENDENCIES)
     set(TBB_ROOT ${GAFFER_ROOT})
     set(OPENEXR_ROOT ${GAFFER_ROOT})
     set(CORTEX_ROOT ${GAFFER_ROOT})
+    set(FMT_ROOT ${GAFFER_ROOT})
 endif()
 
 set(DEPENDENCY_INCLUDE_PATHS
@@ -32,6 +33,7 @@ set(DEPENDENCY_INCLUDE_PATHS
     ${OPENEXR_ROOT}/include/OpenEXR
     ${CORTEX_ROOT}/include
     ${GAFFER_ROOT}/include
+    ${FMT_ROOT}/include
     ${ATOMS_INCLUDE_PATH}
 )
 


### PR DESCRIPTION
Gaffer 1.3 requires `fmt` lib to be in the search path.
As such, when not using gaffer dependencies, we now need a way to specify where to find `fmt`.

