### PR TITLE
Atoms version 6 build adjustments and support for Gaffer 1.3 with OpenEXR version 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,43 @@ set(DEPENDENCY_INCLUDE_PATHS
     ${ATOMS_INCLUDE_PATH}
 )
 
+# If no OpenEXR major version is passed as an argument
+# we try to read the version from the OpenEXR cmake package config.
+if(NOT OPENEXR_MAJOR_VERSION)
+  # We assume OpenEXR being installed with their cmake package config files
+  # (normally in `lib/cmake` within the installation directory). So we add
+  # the root install directory to CMAKE_PREFIX_PATH for find_package
+  # to work
+  list(APPEND CMAKE_PREFIX_PATH ${OPENEXR_ROOT})
+  find_package(OpenEXR PATHS ${OPENEXR_ROOT} CONFIG)
+endif()
+
+# For OpenEXR version 3 and up, we have to add the Imath includes explicitly.
+# We are trying to find the Imath cmake package config and read it's
+# interface include directories to append them to the include path.
+# This works with gaffer dependencies as well with own builds of OpenEXR and Imath
+# which have their cmake directory anywhere in cmakes package search paths
+# As a fallback the root directory can be set via `IMATH_ROOT`.
+if(${OpenEXR_VERSION_MAJOR} AND ${OpenEXR_VERSION_MAJOR} VERSION_GREATER "2")
+  if(NOT IMATH_ROOT)
+    find_package(Imath CONFIG)
+    get_target_property(IMATH_INCLUDES Imath::ImathConfig INTERFACE_INCLUDE_DIRECTORIES)
+    list(APPEND DEPENDENCY_INCLUDE_PATHS ${IMATH_INCLUDES})
+  else()
+    list(APPEND DEPENDENCY_INCLUDE_PATHS "${IMATH_ROOT}/include")
+    list(APPEND DEPENDENCY_INCLUDE_PATHS "${IMATH_ROOT}/include/Imath")
+  endif()
+elseif(${OPENEXR_MAJOR_VERSION} AND ${OPENEXR_MAJOR_VERSION} VERSION_GREATER "2")
+  if(NOT IMATH_ROOT)
+    find_package(Imath CONFIG)
+    get_target_property(IMATH_INCLUDES Imath::ImathConfig INTERFACE_INCLUDE_DIRECTORIES)
+    list(APPEND DEPENDENCY_INCLUDE_PATHS ${IMATH_INCLUDES})
+  else()
+    list(APPEND DEPENDENCY_INCLUDE_PATHS "${IMATH_ROOT}/include")
+    list(APPEND DEPENDENCY_INCLUDE_PATHS "${IMATH_ROOT}/include/Imath")
+  endif()
+endif()
+
 # The Atoms version is defined in the AtomsUtils/Version.h file. We read
 # and parse it here for the major version
 if(NOT ATOMS_MAJOR_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if(USE_GAFFER_DEPENDENCIES)
     set(TBB_ROOT ${GAFFER_ROOT})
     set(OPENEXR_ROOT ${GAFFER_ROOT})
     set(CORTEX_ROOT ${GAFFER_ROOT})
+    set(FMT_ROOT ${GAFFER_ROOT})
 endif()
 
 set(DEPENDENCY_INCLUDE_PATHS
@@ -32,6 +33,7 @@ set(DEPENDENCY_INCLUDE_PATHS
     ${OPENEXR_ROOT}/include/OpenEXR
     ${CORTEX_ROOT}/include
     ${GAFFER_ROOT}/include
+    ${FMT_ROOT}/include
     ${ATOMS_INCLUDE_PATH}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,26 @@ set(DEPENDENCY_INCLUDE_PATHS
     ${ATOMS_INCLUDE_PATH}
 )
 
+# The Atoms version is defined in the AtomsUtils/Version.h file. We read
+# and parse it here for the major version
+if(NOT ATOMS_MAJOR_VERSION)
+  find_file(ATOMS_VERSION_H "Version.h" ${ATOMS_INCLUDE_PATH}/AtomsUtils NO_CACHE)
+  file(READ ${ATOMS_VERSION_H} ATOMS_VERSION_CONTENT)
+  string(REGEX MATCH "ATOMS_MAJOR_VERSION ([0-9]*)" _ ${ATOMS_VERSION_CONTENT})
+  set(ATOMS_MAJOR_VERSION ${CMAKE_MATCH_1})
+endif()
+
+# In Atoms 6 the half type definition was moved into the Atoms namespace.
+# When for example including AtomsUtils/Logger.h it will pull the half.h shipped with
+# Atoms into the file. Since we want to use the one coming with our Imath
+# version, we instruct the preprocessor to include `half.h` as if it was
+# the first instruction in whatever source file and it will include a `half.h`
+# found in one of the include paths (which we asume to be OpenExr/Imath).
+# We make this version dependent to keep the previous behavior for older (re)builds.
+if(ATOMS_MAJOR_VERSION VERSION_GREATER_EQUAL "6")
+  add_compile_options( -include "half.h" )
+endif()
+
 # build the library
 file( GLOB AtomsGafferSrc src/AtomsGaffer/*.cpp )
 link_directories( AtomsGaffer ${GAFFER_ROOT}/lib ${ATOMS_LIB_PATH} )
@@ -44,7 +64,11 @@ add_library( AtomsGaffer SHARED ${AtomsGafferSrc} )
 target_compile_definitions( AtomsGaffer PRIVATE BOOST_SIGNALS_NO_DEPRECATION_WARNING=1 LINUX=1 _GLIBCXX_USE_CXX11_ABI=0)
 target_include_directories( AtomsGaffer SYSTEM PRIVATE ${DEPENDENCY_INCLUDE_PATHS} )
 target_include_directories( AtomsGaffer PRIVATE include )
-target_link_libraries( AtomsGaffer Gaffer GafferScene AtomsCore AtomsGraph Atoms AtomsUtils )
+# Since Atoms version 6, symbols from AtomsCore, AtomsGraph and AtomsUtils have been
+# moved to the Atoms library, so we only link against the former for Atoms versions
+# less than 6.
+set(ATOMS_ADDITIONAL_LINK_LIBS AtomsCore AtomsGraph AtomsUtils)
+target_link_libraries( AtomsGaffer Gaffer GafferScene Atoms "$<$<VERSION_LESS:${ATOMS_MAJOR_VERSION},6>:${ATOMS_ADDITIONAL_LINK_LIBS}>")
 install( TARGETS AtomsGaffer DESTINATION lib )
 
 # build the python bindings


### PR DESCRIPTION
Gaffer 1.3 and up have a requirement on the `fmt` formatting library. We add a variable for it's root directory for builds with gaffer dependencies as well as custom builds.

Release of version 6 of Atoms has incompatible changes with previous versions. Included headers from Atoms previously pulled in their definition of the `half` type, which is from now on correctly namespaced. It is preferred to use OpenEXR/Imath from gaffer dependencies or custom builds. 

Instead of changing the source files and include `half.h` explicitly in source files, we instruct the preprocessor to include `half.h`, provided by our dependencies, before any other header.

Furthermore, symbols previously provided by the `AtomsCore`, `AtomsUtils` and the `AtomsGraph` libraries are all build into the `Atoms` library. We adjust the target link options accordingly.

Additionally we address for the split of `Imath` and `OpenEXR` starting with the version 3 release of `OpenEXR`. If no options are provided during configuration, we rely on cmake's `find_package` to figure out the version and the corresponding include directories. If the cmake configuration files are not available, `OPENEXR_MAJOR_VERSION` and `IMATH_ROOT` can be set directly.